### PR TITLE
fix: unpinning jupyter-manager

### DIFF
--- a/notebooks/Dockerfile
+++ b/notebooks/Dockerfile
@@ -17,7 +17,7 @@ RUN conda install --quiet --yes \
     # Activate ipywidgets extension in the environment that runs the notebook server
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^1.0.1 --no-build && \
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build && \
     # Activate jupytext in the environment that runs the notebook server
     jupyter nbextension enable jupytext --py --sys-prefix && \
     jupyter lab build && \


### PR DESCRIPTION
Having it pinned eventually resulted in
it not being possible to build the image
as the underlying base image changed